### PR TITLE
rec_mdu.cpp: Fix recDIV register signedness

### DIFF
--- a/src/recompiler/mips/rec_mdu.cpp.h
+++ b/src/recompiler/mips/rec_mdu.cpp.h
@@ -297,8 +297,8 @@ static void recDIV()
 	if (rt_const)
 	{
 		// Check rs_const before using rs_val value here!
-		u32 rs_val = GetConst(_Rs_);
-		u32 rt_val = GetConst(_Rt_);
+		s32 rs_val = GetConst(_Rs_);
+		s32 rt_val = GetConst(_Rt_);
 
 		if (!rt_val) {
 			// If divisor operand is const 0:


### PR DESCRIPTION
This was failing to compile for me on GCC7 as it didn't know which overload of `abs` to pick on lines 354 and 360.